### PR TITLE
ci(dependabot): do not run OpenShift-related jobs

### DIFF
--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -19,6 +19,7 @@ jobs:
   # Clean up OpenShift when PR closed, no conditions
   cleanup-openshift:
     name: Cleanup OpenShift
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     environment:
       name: dev
@@ -44,7 +45,10 @@ jobs:
     environment:
       name: test
     runs-on: ubuntu-22.04
-    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
+    if: >
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.actor != 'dependabot[bot]'
     steps:
       - name: Check for image changes
         id: check
@@ -92,7 +96,10 @@ jobs:
   merge-notification:
     name: Merge Notification
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
+    if: >
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.actor != 'dependabot[bot]'
     steps:
       - name: Pre-merge update
         uses: mshick/add-pr-comment@v1

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -312,7 +312,15 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          load: true
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}:${{ env.ZONE }}-${{ env.COMPONENT }}
+
+      - name: Push Docker image
+        if: github.actor != 'dependabot[bot]'
         uses: docker/build-push-action@v3
         with:
           context: .
@@ -320,6 +328,7 @@ jobs:
           tags: ${{ env.REGISTRY }}/${{ github.repository }}:${{ env.ZONE }}-${{ env.COMPONENT }}
 
       - name: Clear any previous OpenShift image
+        if: github.actor != 'dependabot[bot]'
         run: |
           # Login to OpenShift and select project
           oc login --token=${{ secrets.OC_TOKEN }} --server=${{ secrets.OC_SERVER }}
@@ -335,7 +344,10 @@ jobs:
       COMPONENT: database
       ZONE: ${{ github.event.number }}
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main'
+    if: >
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.actor != 'dependabot[bot]'
     needs:
       - build-spar-api
     permissions:
@@ -378,7 +390,10 @@ jobs:
     needs:
       - build-database
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main'
+    if: >
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.actor != 'dependabot[bot]'
     timeout-minutes: 15
     env:
       ZONE: ${{ github.event.number }}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

We don't plan on merging the pull requests opened by Dependabot directly: we'll open a new branch with their changes and create a PR on our own instead of it, so that we don't have to give it access to our OpenShift tokens.

Therefore, we're modifying the conditions of the jobs and steps that use OpenShift tokens so that they are not ran commits and PRs made by Dependabot.

Fixes [FSADT2-348](https://apps.nrs.gov.bc.ca/int/jira/browse/FSADT2-348)

## Type of change

CI modification

# How Has This Been Tested?

It hasn't. Changes were made according to GitHub's recommendations for Dependabot, but we'll only be able to see it in action once this is approved and Dependabot opens a new PR.

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
